### PR TITLE
Add first CLP module with test transaction/cli

### DIFF
--- a/cmd/thorchaincli/main.go
+++ b/cmd/thorchaincli/main.go
@@ -18,6 +18,7 @@ import (
 	ibccmd "github.com/cosmos/cosmos-sdk/x/ibc/client/cli"
 	slashingcmd "github.com/cosmos/cosmos-sdk/x/slashing/client/cli"
 	stakecmd "github.com/cosmos/cosmos-sdk/x/stake/client/cli"
+	clpcmd "github.com/thorchain/THORChain/x/clp/client/cli"
 )
 
 // rootCmd is the entry point for this binary
@@ -121,6 +122,19 @@ func main() {
 		)...)
 	rootCmd.AddCommand(
 		govCmd,
+	)
+
+	//Add CLP commands
+	clpCmd := &cobra.Command{
+		Use:   "clp",
+		Short: "CLP Subcommands",
+	}
+	clpCmd.AddCommand(
+		client.PostCommands(
+			clpcmd.TestTxCmd(cdc),
+		)...)
+	rootCmd.AddCommand(
+		clpCmd,
 	)
 
 	//Add auth and bank commands

--- a/x/clp/client/cli/tx.go
+++ b/x/clp/client/cli/tx.go
@@ -1,0 +1,43 @@
+package clp
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/thorchain/THORChain/x/clp"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/wire"
+	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+)
+
+// run the test transaction
+func TestTxCmd(cdc *wire.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "test [string]",
+		Short: "Test me?",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.NewCoreContextFromViper().WithDecoder(authcmd.GetAccountDecoder(cdc))
+
+			// get the from address from the name flag
+			from, err := ctx.GetFromAddress()
+			if err != nil {
+				return err
+			}
+
+			// create the message
+			msg := clp.NewMsgTest(from, args[0])
+
+			// get account name
+			name := ctx.FromAddressName
+
+			// build and sign the transaction, then broadcast to Tendermint
+			err = ctx.EnsureSignBuildBroadcast(name, []sdk.Msg{msg}, cdc)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}

--- a/x/clp/errors.go
+++ b/x/clp/errors.go
@@ -1,0 +1,10 @@
+package clp
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+//Exported code type numbers
+const (
+	DefaultCodespace sdk.CodespaceType = 14
+)

--- a/x/clp/handler.go
+++ b/x/clp/handler.go
@@ -1,0 +1,28 @@
+package clp
+
+import (
+	"fmt"
+	"reflect"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// NewHandler returns a handler for "clp" type messages.
+func NewHandler(keeper Keeper) sdk.Handler {
+	return func(context sdk.Context, msg sdk.Msg) sdk.Result {
+		switch msg := msg.(type) {
+		case MsgTest:
+			return handleMsgTest(keeper, context, msg)
+		default:
+			errMsg := fmt.Sprintf("Unrecognized test Msg type: %v", reflect.TypeOf(msg).Name())
+			return sdk.ErrUnknownRequest(errMsg).Result()
+		}
+	}
+}
+
+// Handle MsgQuiz This is the engine of your module
+func handleMsgTest(k Keeper, ctx sdk.Context, msg MsgTest) sdk.Result {
+	// k.setTrend(ctx, msg.Cool)
+	fmt.Println("test message being handled!")
+	return sdk.Result{}
+}

--- a/x/clp/keeper.go
+++ b/x/clp/keeper.go
@@ -1,0 +1,20 @@
+package clp
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+)
+
+// Keeper - handlers sets/gets of custom variables for your module
+type Keeper struct {
+	storeKey sdk.StoreKey // The (unexposed) key used to access the store from the Context.
+
+	bankKeeper bank.Keeper
+
+	codespace sdk.CodespaceType
+}
+
+// NewKeeper - Returns the Keeper
+func NewKeeper(key sdk.StoreKey, bankKeeper bank.Keeper, codespace sdk.CodespaceType) Keeper {
+	return Keeper{key, bankKeeper, codespace}
+}

--- a/x/clp/types.go
+++ b/x/clp/types.go
@@ -1,0 +1,59 @@
+package clp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Test type
+type MsgTest struct {
+	Sender sdk.AccAddress
+	Test   string
+}
+
+// new test message
+func NewMsgTest(sender sdk.AccAddress, test string) MsgTest {
+	return MsgTest{
+		Sender: sender,
+		Test:   test,
+	}
+}
+
+// enforce the msg type at compile time
+var _ sdk.Msg = MsgTest{}
+
+// Get MsgTest Type
+func (msg MsgTest) Type() string { return "clp" }
+
+//Get Test Signers
+func (msg MsgTest) GetSigners() []sdk.AccAddress {
+	fmt.Println("getting test signers")
+	return []sdk.AccAddress{msg.Sender}
+}
+
+func (msg MsgTest) String() string {
+	return fmt.Sprintf("MsgTest{Sender: %v, Test: %v}", msg.Sender, msg.Test)
+}
+
+// Validate Basic is used to quickly disqualify obviously invalid messages quickly
+func (msg MsgTest) ValidateBasic() sdk.Error {
+	if len(msg.Sender) == 0 {
+		return sdk.ErrUnknownAddress(msg.Sender.String()).TraceSDK("")
+	}
+	if strings.Contains(msg.Test, "bad") {
+		return sdk.ErrUnauthorized("").TraceSDK("bad test")
+	}
+	return nil
+}
+
+// Get the bytes for the message signer to sign on
+func (msg MsgTest) GetSignBytes() []byte {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+	return sdk.MustSortJSON(b)
+}

--- a/x/clp/wire.go
+++ b/x/clp/wire.go
@@ -1,0 +1,7 @@
+package clp
+
+import "github.com/cosmos/cosmos-sdk/wire"
+
+func RegisterWire(cdc *wire.Codec) {
+	cdc.RegisterConcrete(MsgTest{}, "clp/MsgTest", nil)
+}


### PR DESCRIPTION
This adds a simple clp module with a single, basic working test command that does nothing.
It will be used as a skeleton for CLP functionality and has Amino Wire/Types setup, CLI setup and a basic Keeper and Handler.

Next steps are to add REST client, increase functionality such that it can write and read to the KVstore, and then build out proper CLP functionality thereafter.